### PR TITLE
Fix SetTypeOfNumber encoding

### DIFF
--- a/encoding/tpdu/address.go
+++ b/encoding/tpdu/address.go
@@ -118,7 +118,7 @@ func (a *Address) SetNumberingPlan(np NumberingPlan) {
 
 // SetTypeOfNumber sets the TON field in the TOA.
 func (a *Address) SetTypeOfNumber(ton TypeOfNumber) {
-	a.TOA = (a.TOA &^ 0x30) | (byte(ton&0x3) << 4)
+	a.TOA = (a.TOA &^ 0x70) | (byte(ton&0x7) << 4)
 }
 
 // TypeOfNumber extracts the TON field from the TOA.

--- a/encoding/tpdu/address_test.go
+++ b/encoding/tpdu/address_test.go
@@ -128,7 +128,7 @@ func TestAddressTypeOfNumber(t *testing.T) {
 			a := tpdu.NewAddress()
 			a.SetTypeOfNumber((p))
 			ton := a.TypeOfNumber()
-			if ton != p&0x3 {
+			if ton != p&0x7 {
 				t.Errorf("failed to set and get TypeOfNumber 0x%02x, got 0x%02x", p, ton)
 			}
 		}


### PR DESCRIPTION
SetTypeOfNumber was incorrectly treating the ton value as a 2 bit value instead of 3 bits