### PR TITLE
NewDeliver should return ready to use Deliver structure

### DIFF
--- a/encoding/tpdu/deliver.go
+++ b/encoding/tpdu/deliver.go
@@ -17,7 +17,10 @@ type Deliver struct {
 
 // NewDeliver creates a Deliver TPDU and initialises non-zero fields.
 func NewDeliver() *Deliver {
-	return &Deliver{TPDU: TPDU{FirstOctet: byte(MtDeliver)}}
+	return &Deliver{
+		TPDU: TPDU{FirstOctet: byte(MtDeliver)},
+		OA: Address{TOA: 0x80},
+	}
 }
 
 // MaxUDL returns the maximum number of octets that can be encoded into the UD.


### PR DESCRIPTION
NewDeliver was returning a structure that didn't have the OA.TOA field correctly initialized to 0x80